### PR TITLE
Fix dialogues and rendering

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -134,10 +134,10 @@ $(function(){
     });
 
     $('#biostructureFileButton').on("click", function(){
-        dialog.showOpenDialog({filters: [{name: '.gcode', extensions: ['gcode']}]}, function (fileNames) {
-             if (fileNames === undefined){
-               return;
-             }
+        dialog.showOpenDialog(BrowserWindow, {properties: ["openFile"]}).then(function (result) {
+            if (result.cancelled) {
+                return;
+            }
 
              if(availablePrintSlots(printAreas) == 0)
              {
@@ -145,7 +145,7 @@ $(function(){
                return;
              }
 
-             fs.readFile(fileNames[0], 'utf-8', function (err, data) {
+             fs.readFile(result.filePaths[0], 'utf-8', function (err, data) {
                  if(err){
                      dialog.showErrorBox("", "An error ocurred loading the file: " + err.message);
                      return;
@@ -182,7 +182,7 @@ $(function(){
                      var biostructureQuantity = Math.min($('#biostructureQuantity').val(), availablePrintSlots(printAreas));
                      var usedSlots = printAreas.length - availablePrintSlots(printAreas);
 
-                     $('#biostructure-list').append('<li class="list-group-item justify-content-between">' + fileNames[0].substring(fileNames[0].lastIndexOf('/')+1) + '<span class="badge badge-default badge-pill">'+ biostructureQuantity +'</span></li>');
+                     $('#biostructure-list').append('<li class="list-group-item justify-content-between">' + result.filePaths[0].substring(result.filePaths[0].lastIndexOf('/')+1) + '<span class="badge badge-default badge-pill">'+ biostructureQuantity +'</span></li>');
 
                      for(var i = 0; i < biostructureQuantity; i++){
                          biostructureGCodes.push(data);

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { BrowserWindow } = require('@electron/remote');
+
 // hide the input until an appropriate
 $('#biostructureQuantity').parent().hide();
 
@@ -44,12 +46,14 @@ function limitTo3DecimalPlaces(number) {
 // move the target's center to bed's center
 function centerContainer(container) {
     var bbox = new THREE.Box3().setFromObject(container);
-    var toCenterAxis = bbox.getCenter().negate();
+    var toCenterAxis = new THREE.Vector3(); 
+    bbox.getCenter(toCenterAxis);
+    toCenterAxis.negate();
     toCenterAxis.normalize();
-    container.translateOnAxis(toCenterAxis, bbox.getCenter().length());
+    container.translateOnAxis(toCenterAxis, toCenterAxis.length());
 
     bbox.setFromObject(bed);
-    toCenterAxis = bbox.getCenter();
+    bbox.getCenter(toCenterAxis);
     container.translateX(toCenterAxis.x);
     container.translateY(toCenterAxis.y);
     container.translateZ(bbox.min.z);
@@ -113,9 +117,8 @@ function loadTargetContainerFromObjFile(fileName) {
 // connect events with callbacks
 $(function(){
     $('#loadTargetContainerButton').on("click", function(){
-        dialog.showOpenDialog({filters: [{name: '.obj', extensions: ['obj']}]}, function (fileNames) {
-            // the dialog calls this function with an undefined variable, when the user cancels the selection.
-            if (fileNames === undefined){
+        dialog.showOpenDialog(BrowserWindow, {properties: ["openFile"]}).then(function (result) {
+            if (result.cancelled) {
                 return;
             }
 
@@ -126,7 +129,7 @@ $(function(){
             }
 
             // load new target container
-            loadTargetContainerFromObjFile(fileNames[0]);
+            loadTargetContainerFromObjFile(result.filePaths[0]);
         });
     });
 

--- a/frontend/js/loaders/OBJLoader.js
+++ b/frontend/js/loaders/OBJLoader.js
@@ -683,11 +683,11 @@ THREE.OBJLoader.prototype = {
 
 			var buffergeometry = new THREE.BufferGeometry();
 
-			buffergeometry.addAttribute( 'position', new THREE.BufferAttribute( new Float32Array( geometry.vertices ), 3 ) );
+			buffergeometry.setAttribute( 'position', new THREE.BufferAttribute( new Float32Array( geometry.vertices ), 3 ) );
 
 			if ( geometry.normals.length > 0 ) {
 
-				buffergeometry.addAttribute( 'normal', new THREE.BufferAttribute( new Float32Array( geometry.normals ), 3 ) );
+				buffergeometry.setAttribute( 'normal', new THREE.BufferAttribute( new Float32Array( geometry.normals ), 3 ) );
 
 			} else {
 
@@ -697,7 +697,7 @@ THREE.OBJLoader.prototype = {
 
 			if ( geometry.uvs.length > 0 ) {
 
-				buffergeometry.addAttribute( 'uv', new THREE.BufferAttribute( new Float32Array( geometry.uvs ), 2 ) );
+				buffergeometry.setAttribute( 'uv', new THREE.BufferAttribute( new Float32Array( geometry.uvs ), 2 ) );
 
 			}
 


### PR DESCRIPTION
Electron 15 removed some of the dialogue calls which we used. I replaced them with the recommended new calls.

Further Three.js (r125) removed the `Geometry` class, which is now replaced by the `BufferGeometry` class. Also the interface for `getcenter` changed from returning the center to writing the center into the first argument.

This PR should address #15 .

Tested against the following files:

<details>
<summary>minimal-container.mtl</summary>

```
# Blender MTL File: 'None'
# Material Count: 2

newmtl Material
Ns 359.999993
Ka 1.000000 1.000000 1.000000
Kd 0.800000 0.800000 0.800000
Ks 0.500000 0.500000 0.500000
Ke 0.000000 0.000000 0.000000
Ni 1.450000
d 1.000000
illum 2

newmtl PrintArea
Ns 250.000000
Ka 1.000000 1.000000 1.000000
Kd 0.800000 0.800000 0.800000
Ks 0.500000 0.500000 0.500000
Ke 0.000000 0.000000 0.000000
Ni 1.450000
d 0.000000
illum 9
```
</details>

<details>
<summary>minimal-container.obj</summary>

```
# Blender v3.1.2 OBJ File: ''
# www.blender.org
mtllib minimal-container.mtl
o Cube1
v 1.000000 1.000000 -0.500000
v 1.000000 1.000000 -1.500000
v 1.000000 -1.000000 -0.500000
v 1.000000 -1.000000 -1.500000
v -1.000000 1.000000 -0.500000
v -1.000000 1.000000 -1.500000
v -1.000000 -1.000000 -0.500000
v -1.000000 -1.000000 -1.500000
vt 0.625000 0.500000
vt 0.875000 0.500000
vt 0.875000 0.750000
vt 0.625000 0.750000
vt 0.375000 0.750000
vt 0.625000 1.000000
vt 0.375000 1.000000
vt 0.375000 0.000000
vt 0.625000 0.000000
vt 0.625000 0.250000
vt 0.375000 0.250000
vt 0.125000 0.500000
vt 0.375000 0.500000
vt 0.125000 0.750000
vn 0.0000 -0.0000 1.0000
vn 0.0000 -1.0000 0.0000
vn -1.0000 0.0000 0.0000
vn 0.0000 0.0000 -1.0000
vn 1.0000 0.0000 0.0000
vn 0.0000 1.0000 0.0000
usemtl Material
s off
f 1/1/1 5/2/1 7/3/1 3/4/1
f 4/5/2 3/4/2 7/6/2 8/7/2
f 8/8/3 7/9/3 5/10/3 6/11/3
f 6/12/4 2/13/4 4/5/4 8/14/4
f 2/13/5 1/1/5 3/4/5 4/5/5
f 6/11/6 5/10/6 1/1/6 2/13/6
o Cube2
v -1.000000 -1.000000 -0.500000
v -1.000000 -1.000000 0.500000
v -1.000000 1.000000 -0.500000
v -1.000000 1.000000 0.500000
v 1.000000 -1.000000 -0.500000
v 1.000000 -1.000000 0.500000
v 1.000000 1.000000 -0.500000
v 1.000000 1.000000 0.500000
vt 0.375000 0.000000
vt 0.625000 0.000000
vt 0.625000 0.250000
vt 0.375000 0.250000
vt 0.625000 0.500000
vt 0.375000 0.500000
vt 0.625000 0.750000
vt 0.375000 0.750000
vt 0.625000 1.000000
vt 0.375000 1.000000
vt 0.125000 0.500000
vt 0.125000 0.750000
vt 0.875000 0.500000
vt 0.875000 0.750000
vn -1.0000 0.0000 0.0000
vn 0.0000 1.0000 0.0000
vn 1.0000 0.0000 0.0000
vn 0.0000 -1.0000 0.0000
vn 0.0000 0.0000 -1.0000
vn 0.0000 -0.0000 1.0000
usemtl PrintArea
s off
f 9/15/7 10/16/7 12/17/7 11/18/7
f 11/18/8 12/17/8 16/19/8 15/20/8
f 15/20/9 16/19/9 14/21/9 13/22/9
f 13/22/10 14/21/10 10/23/10 9/24/10
f 11/25/11 15/20/11 13/22/11 9/26/11
f 16/19/12 12/27/12 10/28/12 14/21/12
```
</details>

<details>
<summary>quad.gcode</summary>

```
G1 X5.0 Y5.0 Z0.1 F0.0
G1 X3.0 Y5.0 Z0.1 F1.0
G1 X3.0 Y3.0 Z0.1 F1.0
G1 X5.0 Y3.0 Z0.1 F1.0
G1 X5.0 Y5.0 Z0.1 F1.0
```
</details>